### PR TITLE
feat: allow usage with libraries

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,3 +9,21 @@ jobs:
         with:
           targets: x86_64-unknown-linux-gnu
       - run: cargo test
+
+  library-usage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          targets: x86_64-unknown-linux-gnu
+      - run: cargo build -p library
+
+  binary-usage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          targets: x86_64-unknown-linux-gnu
+      - run: cargo build -p binary

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,11 +1,11 @@
 name: Build
 on: [push]
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@nightly
         with:
-          targets: x86_64-unknown-linux-musl
+          targets: x86_64-unknown-linux-gnu
       - run: cargo test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "binary"
+version = "0.1.0"
+dependencies = [
+ "library",
+ "lumbermill",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -41,6 +49,13 @@ name = "libc"
 version = "0.2.141"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3304a64d199bb964be99741b7a14d26972741915b3649639149b2479bb46f4b5"
+
+[[package]]
+name = "library"
+version = "0.1.0"
+dependencies = [
+ "lumbermill",
+]
 
 [[package]]
 name = "lock_api"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,12 @@ homepage = "https://github.com/sdnts/lumbermill-rs"
 repository = "https://github.com/sdnts/lumbermill-rs"
 version = "0.1.2"
 
+[workspace]
+members = [
+  # Crates here are only used for experimentation, they aren't part of lumbermill
+  "sandbox/*"
+]
+
 [dependencies]
 parking_lot = "0.12.1"
 time = { version = "0.3.20", features = ["std", "formatting"] }

--- a/sandbox/binary/Cargo.toml
+++ b/sandbox/binary/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "binary"
+description = "A sample binary that depends on lumbermill"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+library = { path = "../library" }
+lumbermill = { path = "../../" }

--- a/sandbox/binary/src/main.rs
+++ b/sandbox/binary/src/main.rs
@@ -1,0 +1,6 @@
+use lumbermill::Logger;
+
+fn main() {
+  Logger::default().init();
+  library::add(1, 2);
+}

--- a/sandbox/library/Cargo.toml
+++ b/sandbox/library/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "library"
+description = "A sample library that depends on lumbermill"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+lumbermill = { path = "../../" }

--- a/sandbox/library/src/lib.rs
+++ b/sandbox/library/src/lib.rs
@@ -1,0 +1,6 @@
+use lumbermill::info;
+
+pub fn add(left: usize, right: usize) -> usize {
+  info!(left, right, "Adding");
+  left + right
+}

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -223,14 +223,21 @@ macro_rules! __internal_log {
 
   // entrypoint
   ($lvl:expr, $($fields:tt)+) => {
-    $crate::LOGGER.get().expect("Logger was not initialized").log($crate::Log {
-      timestamp: $crate::OffsetDateTime::now_utc(),
-      level: $lvl,
-      module: module_path!(),
-      file: file!(),
-      line: line!(),
-      kv: $crate::__internal_log!({ }, $($fields)*)
-    });
+    // Ignore returned Option so the lumbermill can be used in other libraries.
+    // It also allows lumbermill to be completely optimized away if a Logger is
+    // never initialized.
+    _ = $crate::LOGGER
+      .get()
+      .map(|l|
+        l.log($crate::Log {
+          timestamp: $crate::OffsetDateTime::now_utc(),
+          level: $lvl,
+          module: module_path!(),
+          file: file!(),
+          line: line!(),
+          kv: $crate::__internal_log!({ }, $($fields)*)
+        })
+      )
   };
 }
 


### PR DESCRIPTION
Libraries generally do not initialize a Logger, and instead leave it up to their consumers to do so. Up until now, macro calls force-panicked in such cases, but they do not anymore