### PR TITLE
New format and slight refactoring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,9 +72,16 @@ name = "lumbermill"
 version = "0.1.4"
 dependencies = [
  "ctor",
+ "owo-colors",
  "parking_lot",
  "time",
 ]
+
+[[package]]
+name = "owo-colors"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 
 [[package]]
 name = "parking_lot"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,11 @@ version = "0.1.4"
 [workspace]
 members = [
   # Crates here are only used for experimentation, they aren't part of lumbermill
-  "sandbox/*"
+  "sandbox/*",
 ]
 
 [dependencies]
+owo-colors = "3.5.0"
 parking_lot = "0.12.1"
 time = { version = "0.3.21", features = ["std", "formatting"] }
 

--- a/src/file.rs
+++ b/src/file.rs
@@ -1,12 +1,14 @@
-use crate::log::{Log, LogFormat};
-use parking_lot::Mutex;
 use std::{
   fs::File,
   io::{self, BufWriter, Write},
   path::{Path, PathBuf},
   sync::atomic::{AtomicUsize, Ordering},
 };
+
+use parking_lot::Mutex;
 use time::{Duration, OffsetDateTime, Time};
+
+use crate::log::{Log, LogFormat};
 
 #[derive(Debug)]
 pub enum RollInterval {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,8 @@
 //!
 //! Macro documentation delves deeper into what you can supply to them. Refer to
 //! it for details.
+//!
+pub use time::OffsetDateTime;
 
 mod file;
 mod log;
@@ -28,7 +30,6 @@ mod stdout;
 pub use file::RollInterval;
 pub use log::{Log, LogFormat, LogLevel};
 pub use logger::{Logger, LOGGER};
-pub use time::OffsetDateTime;
 
 #[cfg(test)]
 #[ctor::ctor]

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,10 +1,11 @@
+use std::{path::PathBuf, sync::OnceLock};
+
 use crate::{
   file::FileLogger,
   log::{Log, LogFormat, LogLevel},
   stdout::StdoutLogger,
   RollInterval,
 };
-use std::{path::PathBuf, sync::OnceLock};
 
 pub static LOGGER: OnceLock<Logger> = OnceLock::new();
 
@@ -39,6 +40,10 @@ impl Logger {
 
   pub fn pretty(self) -> Self {
     self.format(LogFormat::Pretty)
+  }
+
+  pub fn pretty_structured(self) -> Self {
+    self.format(LogFormat::PrettyStructured)
   }
 
   pub fn compact(self) -> Self {


### PR DESCRIPTION
This PR adds a new format named `pretty_structured` which has the same content as the `compact` format (i.e. more structured and easier to parse) while retaining the nice colors that are provided by the `pretty` format.

As an opinionated change and because I think it provides a more visual separation between format and data, I chose to make the `mod=` and `src=` values dimmed. Likewise, I chose to make the other values stand out by colorizing them cyan.

Refactor to use owo-colors since it was tedious to edit color codes otherwise.
Some minor stylistic choices for `use` statements ordering (first std/core imports, then external libs, then crate imports).